### PR TITLE
Update ESP32 column in Porting table.

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,19 +37,19 @@ Microcontroller programming framework.
 
 |           |Raspi Pico|Raspi Pico W|ESP32|
 |-----------|----------|------------|-----|
-|picoruby-adc|✓|✓| |
+|picoruby-adc|✓|✓|✓|
 |picoruby-ble| |✓| |
 |picoruby-cyw43| |✓| |
-|picoruby-env|✓|✓| |
+|picoruby-env|✓|✓|✓ |
 |picoruby-filesystem-fat|✓|✓|✓|
-|picoruby-gpio|✓|✓| |
+|picoruby-gpio|✓|✓|✓|
 |picoruby-i2c|✓|✓| |
 |picoruby-io-console|✓|✓|✓|
 |picoruby-machine|✓|✓|✓|
 |picoruby-net| |✓| |
-|picoruby-pwm|✓|✓| |
-|picoruby-rng|✓|✓| |
-|picoruby-spi|✓|✓| |
+|picoruby-pwm|✓|✓|✓|
+|picoruby-rng|✓|✓|✓|
+|picoruby-spi|✓|✓|✓|
 |picoruby-uart|✓|✓| |
 |picoruby-watchdog|✓|✓| |
 


### PR DESCRIPTION
I have added mrbgems that have completed Porting.

- picoruby-adc
  - https://github.com/picoruby/picoruby/pull/202
- picoruby-env
  - https://github.com/picoruby/picoruby/pull/189
- picoruby-gpio
  - https://github.com/picoruby/picoruby/pull/197
- picoruby-pwm
  - https://github.com/picoruby/picoruby/pull/205
- picoruby-rng
  - https://github.com/picoruby/picoruby/pull/204
- picoruby-spi
  - https://github.com/picoruby/picoruby/pull/203
