### PR TITLE
Add UART and I2c to ESP32 porting.

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,17 +40,17 @@ Microcontroller programming framework.
 |picoruby-adc|✓|✓|✓|
 |picoruby-ble| |✓| |
 |picoruby-cyw43| |✓| |
-|picoruby-env|✓|✓|✓ |
+|picoruby-env|✓|✓|✓|
 |picoruby-filesystem-fat|✓|✓|✓|
 |picoruby-gpio|✓|✓|✓|
-|picoruby-i2c|✓|✓| |
+|picoruby-i2c|✓|✓|✓|
 |picoruby-io-console|✓|✓|✓|
 |picoruby-machine|✓|✓|✓|
 |picoruby-net| |✓| |
 |picoruby-pwm|✓|✓|✓|
 |picoruby-rng|✓|✓|✓|
 |picoruby-spi|✓|✓|✓|
-|picoruby-uart|✓|✓| |
+|picoruby-uart|✓|✓|✓|
 |picoruby-watchdog|✓|✓| |
 
 ### Tutorial of R2P2


### PR DESCRIPTION
I have added mrbgems that have completed Porting.

- picoruby-uart
    - https://github.com/picoruby/picoruby/pull/220
- picoruby-i2c
    - https://github.com/picoruby/picoruby/pull/218