### PR TITLE
bundle exec rake setup was failing due to submodule not being updated…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :install_picoruby => [PICORUBY_DIR, MRUBYC_DIR]
 directory PICORUBY_DIR do
   sh "git clone https://github.com/picoruby/picoruby.git"
   FileUtils.cd("picoruby") do
-    sh "git checkout use-builtin-Task"
+    sh "git submodule update --init --recursive"
   end
   FileUtils.cd("lib") do
     sh "bundle install"
@@ -34,7 +34,7 @@ directory MRUBYC_DIR do
   FileUtils.cd("picoruby/mrbgems/picoruby-mrubyc/lib") do
     sh "git clone https://github.com/mrubyc/mrubyc.git"
     FileUtils.cd("mrubyc") do
-      sh "git checkout fix-picoruby-irb"
+      sh "git submodule update --init --recursive"
     end
   end
 end


### PR DESCRIPTION
…, so I fixed it.

`git checkout xxx` will not check out the branch because it did not exist in the remote repository.
If you need to specify a specific branch, modify the PR.

## Reproduction Steps
1. Clone the repository.
2. Run `bundle exec rake setup` and it completes successfully.
3. Run `bundle exec rake s` and jekyll serve runs locally without any issues.