### PR TITLE
Download latest version from `picoruby/picoruby` repository

### DIFF
--- a/pages/r2p2/setup.md
+++ b/pages/r2p2/setup.md
@@ -69,7 +69,7 @@ This script will:
 
 #### Method 2: Manual Download
 
-- Download the latest *R2P2-PICORUBY-\*.uf2* from GitHub [https://github.com/picoruby/R2P2/releases/latest](https://github.com/picoruby/R2P2/releases/latest) (Of course, unzip or tar it)
+- Download the latest *R2P2-PICORUBY-\*.uf2* from GitHub [https://github.com/picoruby/picoruby/releases/latest](https://github.com/picoruby/picoruby/releases/latest) (Of course, unzip or tar it)
 
   ![*-PICO-*.ufs for Raspi Pico (works on Pico W but no wireless feature. *-PICO2_W-*.uf2 for Pico 2 W (works on Pico 2)](/images/download-r2p2.png)
 

--- a/pages/r2p2/tutorials.md
+++ b/pages/r2p2/tutorials.md
@@ -12,7 +12,7 @@ folder: r2p2
 
 #### 1-1 Getting start with R2P2
 
-- Download the latest `R2P2-*.uf2` from [the releases page of the repository](https://github.com/picoruby/R2P2/releases)
+- Download the latest `R2P2-*.uf2` from [the releases page of the repository](https://github.com/picoruby/picoruby/releases)
 - Drag and drop it into the RPI-RP2 drive
 - Open a proper port in your terminal emulator. See also [terminal-emulator](/terminal-emulator)
 

--- a/r2p2-latest.sh
+++ b/r2p2-latest.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Fetch the latest release and extract .gz asset URLs
-urls=$(curl -s https://api.github.com/repos/picoruby/R2P2/releases/latest |
+urls=$(curl -s https://api.github.com/repos/picoruby/picoruby/releases/latest |
   grep '"browser_download_url"' |
   sed -E 's/.*"browser_download_url": "(.*)".*/\1/' |
   grep '\.gz$')


### PR DESCRIPTION
@hasumikin I have followed the [tutorial](https://picoruby.org/setup) and ran this to set up PicoRuby:

```sh
curl -fsSL https://picoruby.org/r2p2-latest.sh | sh
```

But the `r2p2-latest.sh` tries to download from [picoruby/R2P2](https://github.com/picoruby/R2P2), which should be [picoruby/picoruby](https://github.com/picoruby/picoruby) now.

This PR fixes the above issue and updates related links.