### PR TITLE
Add syntax highlighting to R2P2 terminal editor

### DIFF
--- a/pages/r2p2/editor/editor.css
+++ b/pages/r2p2/editor/editor.css
@@ -1,0 +1,94 @@
+#editor,
+#highlight-content {
+	font-family: "Courier Prime", Courier, monospace;
+	font-size: 15px;
+	line-height: 1.5;
+	white-space: pre;
+	padding: 8px;
+	tab-size: 2;
+}
+
+#editor {
+	overflow: auto;
+	flex: 1;
+	width: 100%;
+	background: #1a1a1a;
+	color: #f8f8f2;
+	caret-color: #f8f8f2;
+	position: relative;
+	z-index: 1;
+	border: none;
+	outline: none;
+	box-sizing: border-box;
+	margin: 0;
+	resize: none;
+	display: block;
+}
+
+#editor::selection {
+	background: rgba(100, 149, 237, 0.4);
+}
+
+#editor::placeholder {
+	color: #444;
+	font-style: italic;
+}
+
+#editor-wrapper {
+	position: relative;
+	flex: 0.6;
+	display: flex;
+	overflow: hidden;
+	background: #1a1a1a;
+	border-right: 1px solid #555;
+}
+
+#highlight-layer {
+	position: absolute;
+	top: 0;
+	left: 0;
+	min-width: 100%;
+	overflow: visible;
+	pointer-events: none;
+	z-index: 0;
+}
+
+#highlight-content {
+	color: #d4d4d4;
+}
+
+.hl-keyword {
+	color: #c586c0;
+}
+.hl-builtin-literal,
+.hl-symbol,
+.hl-interpolation {
+	color: #569cd6;
+}
+.hl-constant {
+	color: #4ec9b0;
+}
+.hl-method {
+	color: #dcdcaa;
+}
+.hl-string {
+	color: #ce9178;
+}
+.hl-escape {
+	color: #d7ba7d;
+}
+.hl-regexp {
+	color: #d16969;
+}
+.hl-number {
+	color: #b5cea8;
+}
+.hl-comment {
+	color: #6a9955;
+}
+.hl-special-variable {
+	color: #9cdcfe;
+}
+.hl-default {
+	color: #d4d4d4;
+}

--- a/pages/r2p2/editor/editor_event_handler.rb
+++ b/pages/r2p2/editor/editor_event_handler.rb
@@ -1,0 +1,41 @@
+module EditorEventHandler
+  def self.init
+    editor = JS.document.getElementById('editor')
+    return if editor.nil?
+
+    plain_button = JS.document.getElementById('editor-mode-plain')
+    ide_button = JS.document.getElementById('editor-mode-ide')
+
+    on editor, 'input' do
+      next unless EditorMode.ide?
+
+      editor.dispatchEvent(JS.global[:Event].new('refresh-highlight'))
+    end
+
+    on editor, 'scroll' do
+      next unless EditorMode.ide?
+
+      editor.dispatchEvent(JS.global[:Event].new('render-highlight-viewport'))
+    end
+
+    on plain_button, 'click' do
+      plain_button[:classList].add('active')
+      ide_button[:classList].remove('active')
+      EditorMode.apply(editor, 'plain')
+    end
+
+    on ide_button, 'click' do
+      plain_button[:classList].remove('active')
+      ide_button[:classList].add('active')
+      EditorMode.apply(editor, 'ide')
+    end
+
+    EditorMode.apply(editor, 'plain')
+  end
+
+  def self.on(target, event_name, &block)
+    target.addEventListener(event_name, &block)
+  end
+end
+
+EditorEventHandler.init

--- a/pages/r2p2/editor/editor_mode.rb
+++ b/pages/r2p2/editor/editor_mode.rb
@@ -1,0 +1,23 @@
+module EditorMode
+  IDE_MODE_VALUE = 'ide'
+  PLAIN_MODE_VALUE = 'plain'
+
+  def self.ide?
+    JS.global[:editorMode].to_s == IDE_MODE_VALUE
+  end
+
+  def self.apply(editor, mode)
+    if mode == IDE_MODE_VALUE
+      JS.global[:editorMode] = IDE_MODE_VALUE
+      # In IDE mode, make the editor textarea text and background transparent so the syntax highlight layer is visible.
+      editor.style[:color] = 'transparent'
+      editor.style[:background] = 'transparent'
+
+      editor.dispatchEvent(JS.global[:Event].new('refresh-highlight'))
+    else
+      JS.global[:editorMode] = PLAIN_MODE_VALUE
+      editor.style[:color] = '#f8f8f2'
+      editor.style[:background] = '#1a1a1a'
+    end
+  end
+end

--- a/pages/r2p2/editor/highlight.rb
+++ b/pages/r2p2/editor/highlight.rb
@@ -1,0 +1,296 @@
+module SyntaxHighlight
+  def self.init
+    editor = JS.document.getElementById('editor')
+    highlight_layer = JS.document.getElementById('highlight-layer')
+    content = JS.document.getElementById('highlight-content')
+
+    session = Session.new(editor, highlight_layer, content)
+    session.attach
+  end
+
+  class Session
+    def initialize(editor, highlight_layer, content)
+      @editor = editor
+      @highlight_layer = highlight_layer
+      @content = content
+      @line_cache = []
+    end
+
+    def attach
+      @editor.addEventListener('refresh-highlight') do
+        refresh_highlight
+      end
+
+      @editor.addEventListener('render-highlight-viewport') do
+        render_highlight_viewport
+      end
+    end
+
+    private
+
+    def refresh_highlight
+      source = @editor[:value].to_s
+
+      if source.empty?
+        clear_highlight
+      else
+        @line_cache = CacheBuilder.rebuild(@line_cache, source)
+        render_highlight_viewport
+      end
+    rescue StandardError
+      p 'refresh highlight error'
+      @line_cache = []
+    end
+
+    def render_highlight_viewport
+      ViewportRenderer.render(
+        @editor,
+        @content,
+        @highlight_layer,
+        @line_cache
+      )
+    rescue StandardError
+      p 'viewport rendering error'
+    end
+
+    def clear_highlight
+      @line_cache = []
+      @content[:style][:paddingTop] = ''
+      @content[:innerHTML] = ''
+      @highlight_layer[:style][:top] = '0px'
+      @highlight_layer[:style][:left] = '0px'
+    end
+  end
+
+  # Cache tokens per input line so unchanged lines can be reused instead of tokenizing every line each time.
+  module CacheBuilder
+    def self.rebuild(cached_line_entries, source)
+      # Keep trailing empty elements with -1 so the input source is represented as complete line data.
+      lines = source.split("\n", -1)
+
+      line_count = lines.length
+      line_delta = line_count - cached_line_entries.length
+      change_start_index = find_change_start_index(lines, cached_line_entries)
+      new_line_entries = cached_line_entries[0, change_start_index]
+
+      lines[change_start_index, line_count].each_with_index do |line_text, offset|
+        line_index = change_start_index + offset
+
+        cached_line_entry =
+          cached_line_entry_for(
+            cached_line_entries,
+            line_index,
+            line_delta
+          )
+
+        if line_cache_valid?(cached_line_entry, line_text)
+          new_line_entries << cached_line_entry
+
+          next
+        end
+
+        new_line_entries << make_line_cache_entry(line_text)
+      end
+
+      new_line_entries
+    end
+
+    def self.find_change_start_index(lines, cached_line_entries)
+      max_index = [lines.length, cached_line_entries.length].min
+
+      max_index.times do |idx|
+        return idx if lines[idx] != cached_line_entries[idx][:line_text]
+      end
+
+      max_index
+    end
+
+    def self.cached_line_entry_for(
+      cached_line_entries,
+      line_index,
+      line_delta
+    )
+      cached_line_entry_index = line_index - line_delta
+
+      if cached_line_entry_index < 0 ||
+         cached_line_entry_index >= cached_line_entries.length
+
+        return nil
+      end
+
+      cached_line_entries[cached_line_entry_index]
+    end
+
+    def self.line_cache_valid?(cached_line_entry, line_text)
+      cached_line_entry && cached_line_entry[:line_text] == line_text
+    end
+
+    def self.make_line_cache_entry(line_text)
+      tokens = Tokenizer.tokenize(line_text)
+
+      {
+        line_text: line_text,
+        tokens: tokens
+      }
+    end
+  end
+
+  module ViewportRenderer
+    BUFFER_LINES = 5
+
+    def self.render(editor, content, highlight_layer, line_cache)
+      return if line_cache.empty?
+
+      line_height, padding_top = editor_metrics(editor)
+
+      first_line_index, last_line_index =
+        visible_line_range(editor, line_cache, line_height, padding_top)
+
+      set_highlight_content(
+        content,
+        line_cache,
+        first_line_index,
+        last_line_index,
+        line_height,
+        padding_top
+      )
+
+      apply_highlight_scroll_offset(editor, highlight_layer)
+    end
+
+    private
+
+    def self.visible_line_range(editor, line_cache, line_height, padding_top)
+      scroll_top = editor[:scrollTop].to_f
+      client_height = editor[:clientHeight].to_f
+
+      first_line_index =
+        first_visible_line_index(scroll_top, line_height, padding_top)
+
+      last_line_index =
+        last_visible_line_index(
+          scroll_top,
+          client_height,
+          line_cache,
+          line_height,
+          padding_top
+        )
+
+      [first_line_index, last_line_index]
+    end
+
+    def self.set_highlight_content(
+      content,
+      line_cache,
+      first_line_index,
+      last_line_index,
+      line_height,
+      padding_top
+    )
+      # Render only the visible range, then fill the height up to the first line with padding to align with the textarea scroll position.
+      content[:style][:paddingTop] =
+        "#{first_line_top_offset(first_line_index, line_height, padding_top)}px"
+
+      content[:innerHTML] =
+        render_visible_html(line_cache, first_line_index, last_line_index)
+    end
+
+    def self.apply_highlight_scroll_offset(editor, highlight_layer)
+      highlight_layer[:style][:top] = "#{-editor[:scrollTop].to_f}px"
+      highlight_layer[:style][:left] = "#{-editor[:scrollLeft].to_f}px"
+    end
+
+    def self.render_visible_html(line_cache, first_line_index, last_line_index)
+      result = []
+
+      (first_line_index..last_line_index).each do |line_index|
+        result << HtmlBuilder.make_line_html(line_cache[line_index])
+
+        if line_index < line_cache.length - 1
+          result << HtmlBuilder.make_newline_html
+        end
+      end
+
+      result.join
+    end
+
+    def self.first_visible_line_index(scroll_top, line_height, padding_top)
+      text_scroll_top = scroll_top - padding_top
+      [(text_scroll_top / line_height).floor - BUFFER_LINES, 0].max
+    end
+
+    def self.last_visible_line_index(
+      scroll_top,
+      client_height,
+      line_cache,
+      line_height,
+      padding_top
+    )
+      text_scroll_bottom = scroll_top + client_height - padding_top
+
+      [
+        (text_scroll_bottom / line_height).ceil + BUFFER_LINES,
+        line_cache.length - 1
+      ].min
+    end
+
+    def self.first_line_top_offset(first_line_index, line_height, padding_top)
+      padding_top + first_line_index * line_height
+    end
+
+    def self.editor_metrics(editor)
+      style = JS.global.getComputedStyle(editor)
+      [
+        style[:lineHeight].to_s.to_f,
+        style[:paddingTop].to_s.to_f
+      ]
+    end
+  end
+
+  module HtmlBuilder
+    TOKEN_CLASSES = {
+      'keyword' => 'hl-keyword',
+      'builtinLiteral' => 'hl-builtin-literal',
+      'constant' => 'hl-constant',
+      'method' => 'hl-method',
+      'string' => 'hl-string',
+      'escape' => 'hl-escape',
+      'regexp' => 'hl-regexp',
+      'symbol' => 'hl-symbol',
+      'number' => 'hl-number',
+      'comment' => 'hl-comment',
+      'specialVariable' => 'hl-special-variable',
+      'interpolation' => 'hl-interpolation',
+      'default' => 'hl-default'
+    }
+
+    def self.make_line_html(entry)
+      entry[:tokens].map { |token| make_token_html(token) }.join
+    end
+
+    def self.make_newline_html
+      make_token_span('default', "\n")
+    end
+
+    private
+
+    def self.make_token_html(token)
+      make_token_span(token[:type], token[:text])
+    end
+
+    def self.make_token_span(type, text)
+      cls = token_class(type)
+      "<span class=\"#{cls}\">#{escape_html(text)}</span>"
+    end
+
+    def self.token_class(type)
+      TOKEN_CLASSES[type] || TOKEN_CLASSES['default']
+    end
+
+    def self.escape_html(text)
+      text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+    end
+  end
+end
+
+SyntaxHighlight.init

--- a/pages/r2p2/editor/tokenizer/lexPrism.js
+++ b/pages/r2p2/editor/tokenizer/lexPrism.js
@@ -1,0 +1,115 @@
+// Convert Prism's serialized lex output into an editor token array.
+export function lexPrism(prism, source) {
+  const sourceBytes = new TextEncoder().encode(source);
+  const sourceBufferPointer = prism.calloc(1, sourceBytes.length);
+  const lexOutputBufferPointer = prism.calloc(prism.pm_buffer_sizeof(), 1);
+
+  prism.pm_buffer_init(lexOutputBufferPointer);
+
+  new Uint8Array(
+    prism.memory.buffer,
+    sourceBufferPointer,
+    sourceBytes.length
+  ).set(sourceBytes);
+
+  prism.pm_serialize_lex(
+    lexOutputBufferPointer,
+    sourceBufferPointer,
+    sourceBytes.length,
+    0 // options
+  );
+
+  const serializedLexBytes = new Uint8Array(
+    prism.memory.buffer,
+    prism.pm_buffer_value(lexOutputBufferPointer),
+    prism.pm_buffer_length(lexOutputBufferPointer)
+  ).slice();
+
+  prism.pm_buffer_free(lexOutputBufferPointer);
+  prism.free(sourceBufferPointer);
+  prism.free(lexOutputBufferPointer);
+
+  return deserializeLex(prism, serializedLexBytes);
+}
+
+function deserializeLex(prism, serializedLexBytes) {
+  const tokens = [];
+  const readToken = createSerializedLexReader(serializedLexBytes);
+  const internTokenTypeName = createTokenTypeNameInterner(prism);
+
+  for (let readCount = 0; readCount < serializedLexBytes.length; readCount++) {
+    const token = readToken();
+    if (token === null) break;
+
+    tokens.push({
+      type: internTokenTypeName(token.type),
+      startOffset: token.startOffset,
+      length: token.length,
+    });
+  }
+
+  return tokens;
+}
+
+function createSerializedLexReader(serializedLexBytes) {
+  const CONTINUATION_BIT_MASK = 0x80;
+  const VALUE_MASK = 0x7f;
+  const END_OF_TOKENS = 0;
+  let pos = 0;
+
+  return function readToken() {
+    // pm_serialize_lex outputs each token as LEB128 varints in token_type, start_offset, length, lex_state order.
+    const tokenTypeOrEndMarker = readVarUint();
+    if (tokenTypeOrEndMarker === END_OF_TOKENS) return null;
+
+    const type = tokenTypeOrEndMarker;
+    const startOffset = readVarUint();
+    const length = readVarUint();
+
+    // Discard lex_state because it is not used.
+    readVarUint();
+
+    return { type, startOffset, length };
+  };
+
+  function readVarUint() {
+    let decodedValue = 0;
+    let shift = 0;
+
+    while (pos < serializedLexBytes.length) {
+      const byte = serializedLexBytes[pos++];
+      decodedValue |= (byte & VALUE_MASK) << shift;
+
+      if ((byte & CONTINUATION_BIT_MASK) === 0) break;
+
+      shift += 7;
+    }
+
+    return decodedValue;
+  }
+}
+
+function createTokenTypeNameInterner(prism) {
+  const cache = new Map();
+  const prismMemory = new Uint8Array(prism.memory.buffer);
+
+  return function internTokenTypeName(type) {
+    const cachedName = cache.get(type);
+
+    if (cachedName !== undefined) {
+      return cachedName;
+    }
+
+    const name = readPrismTokenTypeName(type);
+    cache.set(type, name);
+
+    return name;
+  };
+
+  function readPrismTokenTypeName(type) {
+    const stringPointer = prism.pm_token_type_name(type);
+    const end = prismMemory.indexOf(0, stringPointer);
+
+    return new TextDecoder().decode(prismMemory.subarray(stringPointer, end));
+  }
+}

--- a/pages/r2p2/editor/tokenizer/prismLoader.js
+++ b/pages/r2p2/editor/tokenizer/prismLoader.js
@@ -1,0 +1,21 @@
+// @bjorn3/browser_wasi_shim v0.4.2
+// Licensed under MIT OR Apache-2.0; this project uses it under the MIT License.
+// Source: https://github.com/bjorn3/browser_wasi_shim
+import { WASI } from "https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.4.2/dist/index.js";
+import { lexPrism } from "./lexPrism.js";
+
+const wasm = await WebAssembly.compileStreaming(
+  fetch("https://cdn.jsdelivr.net/npm/@ruby/prism@1.9.0/src/prism.wasm")
+);
+
+// Prism's browser example uses a WASI shim because not all browsers support WASI yet.
+// The shim provides the wasi_snapshot_preview1 imports needed to instantiate prism.wasm.
+const wasi = new WASI([], [], []);
+const instance = await WebAssembly.instantiate(wasm, {
+  wasi_snapshot_preview1: wasi.wasiImport,
+});
+
+wasi.initialize(instance);
+
+window.lexPrism = (source) => lexPrism(instance.exports, source);
+window.prismReady = true;

--- a/pages/r2p2/editor/tokenizer/tokenizer.rb
+++ b/pages/r2p2/editor/tokenizer/tokenizer.rb
@@ -1,0 +1,225 @@
+module Tokenizer
+  KEYWORD_LIKE_IDENTIFIERS = %w[
+    raise
+    fail
+    require
+    include
+    extend
+    prepend
+    attr
+    attr_accessor
+    attr_reader
+    attr_writer
+    public
+    protected
+    private
+    lambda
+    caller
+    eval
+    class_eval
+    instance_eval
+    module_eval
+    exit
+    loop
+    define_method
+    alias_method
+    remove_method
+    undef_method
+  ]
+
+  BUILTIN_LITERAL_TOKENS = %w[
+    KEYWORD_NIL
+    KEYWORD_TRUE
+    KEYWORD_FALSE
+    KEYWORD_SELF
+    KEYWORD___FILE__
+    KEYWORD___ENCODING__
+  ]
+
+  NUMBER_TOKENS = %w[
+    INTEGER
+    FLOAT
+  ]
+
+  SPECIAL_VARIABLE_TOKENS = %w[
+    INSTANCE_VARIABLE
+    CLASS_VARIABLE
+    GLOBAL_VARIABLE
+    BACK_REFERENCE
+    NUMBERED_REFERENCE
+  ]
+
+  INTERPOLATION_TOKENS = %w[
+    EMBEXPR_BEGIN
+    EMBEXPR_END
+    EMBVAR
+  ]
+
+  def self.tokenize(source)
+    # Return a default token to keep the editor working when Prism is unavailable.
+    return [{ type: 'default', text: source }] unless JS.global[:prismReady]
+
+    js_prism_tokens = JS.global.lexPrism(source)
+    build_tokens(source, js_prism_tokens)
+  rescue StandardError
+    p 'tokenize error'
+    [{ type: 'default', text: source }]
+  end
+
+  def self.build_tokens(source, js_prism_tokens)
+    tokens = []
+
+    last_token_end = 0
+    literal_context = nil
+    expect_symbol_name = false
+    expect_method_name = false
+
+    (0...js_prism_tokens[:length].to_i).each do |idx|
+      js_prism_token = js_prism_tokens[idx]
+
+      prism_type = js_prism_token[:type].to_s
+      next if prism_type == 'EOF'
+
+      start_offset = js_prism_token[:startOffset].to_i
+      end_offset = start_offset + js_prism_token[:length].to_i
+
+      # Fill text that Prism does not tokenize with default tokens.
+      if start_offset > last_token_end
+        tokens << make_missing_token(source, last_token_end, start_offset)
+      end
+
+      token_text = source_slice(source, start_offset, end_offset)
+
+      if expect_symbol_name
+        expect_symbol_name = false
+
+        tokens << {
+          type: 'symbol',
+          text: token_text
+        }
+
+        last_token_end = end_offset
+
+        next
+      end
+
+      token_type =
+        case prism_type
+        when 'KEYWORD_DEF'
+          expect_method_name = true
+          'keyword'
+
+        when 'STRING_BEGIN'
+          literal_context = 'string'
+          'string'
+
+        when 'REGEXP_BEGIN'
+          literal_context = 'regexp'
+          'regexp'
+
+        when 'SYMBOL_BEGIN'
+          if token_text == ':'
+            expect_symbol_name = true
+          else
+            literal_context = 'quoted_symbol'
+          end
+
+          'symbol'
+
+        when 'STRING_END', 'LABEL_END'
+          token_type =
+            if literal_context == 'quoted_symbol'
+              'symbol'
+            else
+              'string'
+            end
+
+          literal_context = nil
+          token_type
+
+        when 'REGEXP_END'
+          literal_context = nil
+          'regexp'
+
+        when 'STRING_CONTENT'
+          case literal_context
+          when 'quoted_symbol'
+            'symbol'
+          when 'string', 'regexp'
+            literal_context
+          else
+            'string'
+          end
+
+        when 'CHARACTER_LITERAL'
+          'string'
+
+        when 'LABEL'
+          'symbol'
+
+        when 'CONSTANT'
+          'constant'
+
+        when 'METHOD_NAME'
+          expect_method_name = false
+          'method'
+
+        when *INTERPOLATION_TOKENS
+          'interpolation'
+
+        when 'IDENTIFIER'
+          if expect_method_name
+            expect_method_name = false
+            'method'
+          elsif KEYWORD_LIKE_IDENTIFIERS.include?(token_text)
+            'keyword'
+          else
+            'default'
+          end
+
+        when 'COMMENT'
+          'comment'
+
+        when *SPECIAL_VARIABLE_TOKENS
+          'specialVariable'
+
+        when *NUMBER_TOKENS
+          'number'
+
+        when *BUILTIN_LITERAL_TOKENS
+          'builtinLiteral'
+
+        else
+          if prism_type.start_with?('KEYWORD_')
+            'keyword'
+          else
+            'default'
+          end
+        end
+
+      tokens << {
+        type: token_type,
+        text: token_text
+      }
+
+      last_token_end = end_offset
+    end
+
+    if last_token_end < source.length
+      tokens << make_missing_token(source, last_token_end, source.length)
+    end
+
+    tokens
+  end
+
+  def self.make_missing_token(source, last_token_end, next_token_start)
+    {
+      type: 'default',
+      text: source_slice(source, last_token_end, next_token_start)
+    }
+  end
+
+  def self.source_slice(source, start_offset, end_offset)
+    source.slice(start_offset, end_offset - start_offset).to_s
+  end
+end

--- a/pages/r2p2/r2p2-tools.css
+++ b/pages/r2p2/r2p2-tools.css
@@ -133,6 +133,29 @@ html, body {
 .font-ctrl input[type=number]::-webkit-inner-spin-button { -webkit-appearance: none; }
 
 /* ----------------------------------------------------------------
+ * Editor mode toggle buttons
+ * ---------------------------------------------------------------- */
+.editor-mode-buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.editor-mode-buttons button {
+  padding: 4px 6px;
+  font-size: 9px;
+  line-height: 1;
+  border-radius: 2px;
+  margin: 5px;
+}
+
+.editor-mode-buttons button.active {
+  background: #3a4a5a;
+  color: #fff;
+  border-color: #7ec8e3;
+}
+
+/* ----------------------------------------------------------------
  * Fieldset panel (used in terminal.html File Editor section)
  * ---------------------------------------------------------------- */
 fieldset.tool-panel {
@@ -191,23 +214,6 @@ fieldset.tool-panel legend {
   resize: vertical;
   overflow: hidden;
 }
-
-.editor-container textarea {
-  flex: 0.6;
-  font-family: 'Courier Prime', Courier, monospace;
-  font-size: 14px;
-  background: #1a1a1a;
-  color: #f8f8f2;
-  border: none;
-  border-right: 1px solid #555;
-  padding: 8px;
-  resize: none;
-  tab-size: 2;
-  display: block;
-  overflow-y: auto;
-}
-
-.editor-container textarea::placeholder { color: #444; font-style: italic; }
 
 /* ----------------------------------------------------------------
  * Horizontal col-resizer (drag handle between editor / log)

--- a/pages/r2p2/terminal.html
+++ b/pages/r2p2/terminal.html
@@ -15,6 +15,7 @@ folder: r2p2
   <link rel="stylesheet" href="picoruby.wasm/test.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.0.0/css/xterm.css">
   <link rel="stylesheet" href="pages/r2p2/r2p2-tools.css">
+  <link rel="stylesheet" href="pages/r2p2/editor/editor.css">
   <script src="pages/r2p2/version-selector.js"></script>
   <style>
     body { padding: 4px; }
@@ -22,7 +23,6 @@ folder: r2p2
     #dfu-section legend { font-weight: bold; font-size: 13px; color: #aaa; padding: 0 4px; }
     #path-input { width: 220px; }
     #editor-container { margin: 2px 0; }
-    #editor { font-size: 15px; }
     #dfu-log { font-size: 12px; padding: 4px; }
   </style>
 </head>
@@ -75,7 +75,12 @@ folder: r2p2
       <span id="local-file-path" style="font-family:monospace;font-size:12px;color:#666;"></span>
     </div>
     <div id="editor-container" class="editor-container">
-      <textarea id="editor" spellcheck="false" placeholder="# Type or download Ruby code here..."></textarea>
+      <div id="editor-wrapper">
+        <div id="highlight-layer">
+          <div id="highlight-content"></div>
+        </div>
+        <textarea id="editor" wrap="off" spellcheck="false" placeholder="# Type or download Ruby code here..."></textarea>
+      </div>
       <div id="resizer" class="col-resizer"></div>
       <div id="dfu-log" class="log-panel"></div>
     </div>
@@ -87,6 +92,12 @@ folder: r2p2
           <button id="editor-font-plus">+</button>
         </span>
       </label>
+      <label>Editor mode:
+        <span class="editor-mode-buttons">
+          <button id="editor-mode-plain" type="button" class="active" data-mode="plain">Plain</button>
+          <button id="editor-mode-ide" type="button" data-mode="ide">IDE</button>
+        </span>
+      </label>
     </div>
   </fieldset>
 
@@ -95,5 +106,12 @@ folder: r2p2
 
   <script type="text/ruby" src="pages/r2p2/terminal.rb"></script>
   <!-- wasm script is loaded dynamically by version-selector.js -->
+
+  <!-- Web Editor -->
+  <script type="text/ruby" src="pages/r2p2/editor/editor_mode.rb"></script>
+  <script type="text/ruby" src="pages/r2p2/editor/editor_event_handler.rb"></script>
+  <script type="module" src="pages/r2p2/editor/tokenizer/prismLoader.js"></script>
+  <script type="text/ruby" src="pages/r2p2/editor/tokenizer/tokenizer.rb"></script>
+  <script type="text/ruby" src="pages/r2p2/editor/highlight.rb"></script>
 </body>
 </html>

--- a/pages/r2p2/terminal.rb
+++ b/pages/r2p2/terminal.rb
@@ -73,7 +73,11 @@ class App
   def set_editor_font(val)
     val = [[8, val].max, 24].min
     el('editor-font-size')[:value] = val
-    el('editor').style.fontSize = "#{val}px"
+
+    font_size = "#{val}px"
+    el('editor').style.fontSize = font_size
+    # Match the textarea font size so the highlight display stays aligned.
+    el('highlight-content').style.fontSize = font_size
   end
 
   def set_term_font(val)
@@ -278,12 +282,12 @@ class App
   end
 
   def bind_resizer
-    resizer          = el('resizer')
-    editor_container = el('editor-container')
-    editor_el        = el('editor')
-    dfu_log_el       = el('dfu-log')
-    body             = @doc.body
-    is_resizing      = false
+    resizer           = el('resizer')
+    editor_container  = el('editor-container')
+    editor_wrapper_el = el('editor-wrapper')
+    dfu_log_el        = el('dfu-log')
+    body              = @doc.body
+    is_resizing       = false
 
     resizer.addEventListener('mousedown') do
       is_resizing = true
@@ -293,14 +297,14 @@ class App
 
     @doc.addEventListener('mousemove') do |e|
       next unless is_resizing
-      rect        = editor_container.getBoundingClientRect()
-      new_left_x  = e.clientX.to_f - rect.left.to_f
-      max_x       = rect.width.to_f - 20.0
-      constrained = [100.0, [new_left_x, max_x].min].max
-      left_ratio  = constrained / rect.width.to_f
-      right_ratio = 1.0 - left_ratio
-      editor_el.style.flex  = left_ratio.to_s
-      dfu_log_el.style.flex = right_ratio.to_s
+      rect                         = editor_container.getBoundingClientRect()
+      new_left_x                   = e.clientX.to_f - rect.left.to_f
+      max_x                        = rect.width.to_f - 20.0
+      constrained                  = [100.0, [new_left_x, max_x].min].max
+      left_ratio                   = constrained / rect.width.to_f
+      right_ratio                  = 1.0 - left_ratio
+      editor_wrapper_el.style.flex = left_ratio.to_s
+      dfu_log_el.style.flex        = right_ratio.to_s
     end
 
     @doc.addEventListener('mouseup') do
@@ -319,6 +323,8 @@ class App
       reader = JS.global[:FileReader].new
       reader.addEventListener('load') do |e|
         el('editor')[:value] = e[:target][:result].to_s
+        # Dispatch an input event so EditorEventHandler can handle the update.
+        el('editor').dispatchEvent(JS.global[:Event].new('input'))
         el('local-file-path')[:textContent] = file[:name].to_s
         el('file-input')[:value] = ''
         update_dfu_buttons
@@ -513,6 +519,7 @@ class App
             local_crc = CRC.crc32(data)
             if local_crc == remote_crc
               el('editor')[:value] = data
+              el('editor').dispatchEvent(JS.global[:Event].new('input'))
               append_log("[+] Downloaded #{data.bytesize} bytes (CRC32 verified)")
               success = true
             else
@@ -520,6 +527,7 @@ class App
             end
           else
             el('editor')[:value] = data
+            el('editor').dispatchEvent(JS.global[:Event].new('input'))
             append_log("[+] Downloaded #{data.bytesize} bytes")
             success = true
           end


### PR DESCRIPTION
## Overview
This PR adds syntax highlighting for PicoRuby code to the R2P2 terminal editor.

<img width="838" height="725" alt="image" src="https://github.com/user-attachments/assets/25ba90e5-241e-4b6e-915a-53db4d1f90cd" />

## Changes
- Tokenization for Ruby/PicoRuby code using Prism WASM
- Syntax highlighting using a highlight layer behind the `textarea`
- Moved editor-related CSS into `editor.css`
  - Moved the existing editor styles into `editor.css`
  - Collected the highlight layer styles and token color styles in the same file
- `Plain` / `IDE` mode toggle buttons
  - `Plain` keeps the original `textarea` behavior
  - `IDE` enables syntax highlighting
  - `Plain` is kept as a fallback because IDE mode is newly implemented and may still have issues
- Highlight rendering uses per-line token caching and renders only the visible range

## Not Included

To keep this PR simple, the following items are not included:

- Highlighting across multiple lines, such as `=begin` blocks and multiline strings
- Unit tests

I plan to add these in future PRs.

## Planned Future Additions

After this PR is merged, I plan to submit PRs for the following features:

- Line numbers
- Auto indentation
