### PR TITLE
Fix RuntimeGems upload on small-stack builds by shrinking PicoModem chunk size

### DIFF
--- a/pages/r2p2/runtimegems.rb
+++ b/pages/r2p2/runtimegems.rb
@@ -7,6 +7,8 @@ INDEX_JSON_URL = 'https://raw.githubusercontent.com/picoruby/runtimegems/refs/he
 class App
   TX_CHUNK_SIZE   = 32
   TX_CHUNK_GAP_MS = 20
+  # Upload chunk size; PicoModem::CHUNK_SIZE (480) fails on some device builds.
+  UPLOAD_CHUNK_SIZE = 64
 
   attr_accessor :current_port
 
@@ -354,7 +356,10 @@ class App
   def upload_binary(data, path)
     success = false
     begin
-      picomodem_enter_mode
+      unless picomodem_enter_mode
+        append_log("[-] Could not enter PicoModem mode (no response from device)")
+        return false
+      end
       picomodem_send_frame(PicoModem::FILE_WRITE, [data.bytesize].pack("N") + path)
 
       frame = picomodem_recv_frame
@@ -375,7 +380,7 @@ class App
       offset = 0
       while offset < data.bytesize
         remain = data.bytesize - offset
-        size = remain < PicoModem::CHUNK_SIZE ? remain : PicoModem::CHUNK_SIZE
+        size = remain < UPLOAD_CHUNK_SIZE ? remain : UPLOAD_CHUNK_SIZE
         chunk = data.byteslice(offset, size)
         picomodem_send_frame(PicoModem::CHUNK, chunk)
 
@@ -608,14 +613,19 @@ class App
     JS::WebSerial.capture_start(jsp)
     current_port.write("\x02")
     current_port.drain.await
+    acked = false
     waited = 0
     while waited < PicoModem::TIMEOUT_MS
-      break if JS::WebSerial.capture_peek(jsp).to_s.include?("\x06")
+      if JS::WebSerial.capture_peek(jsp).to_s.include?("\x06")
+        acked = true
+        break
+      end
       sleep_ms 1
       waited += 1
     end
     JS::WebSerial.capture_stop(jsp)
     JS::WebSerial.binary_capture_start(jsp)
+    acked
   end
 
   def picomodem_exit_mode(send_abort = false)


### PR DESCRIPTION
RuntimeGems uploads fail on some device builds. This PR is a small client-side stopgap to unblock them; I'm not sure it's the right layer, so I'm opening it for discussion (see "On where this should be fixed" below).

## Symptom
Uploading a gem to an ESP32 (Xtensa) build fails deterministically: `FILE_ACK` arrives, but the first `CHUNK` never gets a `CHUNK_ACK` (`Timeout at offset 0`).

## Cause (verified)
mruby/c's `read_nonblock` (`picoruby-io-console`) allocates a stack VLA `char buf[maxlen + 1]` sized to the requested read length (byte-identical in 3.4.2 and current). PicoModem reads the whole CHUNK body in one call, so the default 480-byte payload becomes `read_nonblock(483)`, which allocates a 484-byte VLA (`char buf[maxlen + 1]`). On the ESP32 (Xtensa) build I tested this overflows the VM task's stack and the receive breaks; the RP2040/RP2350 builds I tested (also mruby/c) have enough stack and handle it. So it's the build's stack budget, not the chip or the VM type.

## This change (only `pages/r2p2/runtimegems.rb`)
- Send `UPLOAD_CHUNK_SIZE = 64` instead of `PicoModem::CHUNK_SIZE`. The device appends chunks of any size until the declared total, so this stays
  protocol-safe. 
- `picomodem_enter_mode` now reports whether it got the ACK, so `upload_binary` shows a clear "Could not enter PicoModem mode" message instead of a misleading FILE_ACK timeout.
  
## On where this should be fixed
I'm not sure the page is the right place to fix this. The chunk size that's safe seems to depend on the build's stack rather than on anything here, so it might be
better handled upstream (around how `read_nonblock` / PicoModem reads a frame). I went with the small client-side change because it unblocks uploads now, but I'd. happily defer if you'd prefer to address it upstream.

## Testing
Chrome Web Serial, one clean upload each (`picoruby-ws2812`, 3075 B `.mrb`):

| Chip (board tested) | Engine / version | 480 B (default) | 64 B |
| --- | --- | --- | --- |
| ESP32 / Xtensa (M5 AtomMatrix) | mruby/c, 4.0.0 | fails at offset 0 | OK (CRC32 verified) |
| RP2040 (Raspberry Pi Pico) | mruby/c, 3.4.2 | OK | OK |
| RP2350 (Raspberry Pi Pico 2 W) | mruby/c, 3.4.2 | OK | OK |

64 B works on all three; the 480 B failure is specific to the ESP32 build I tested, so reducing the chunk size doesn't regress the others.
