### PR TITLE
Add line numbers to R2P2 terminal editor

### DIFF
--- a/pages/r2p2/editor/editor.css
+++ b/pages/r2p2/editor/editor.css
@@ -57,6 +57,52 @@
 	color: #d4d4d4;
 }
 
+#line-numbers {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 40px;
+	height: 100%;
+	overflow: hidden;
+	background: #1a1a1a;
+	pointer-events: none;
+	z-index: 5; /* Keep line numbers above the editor and highlight layer. */
+	display: none;
+}
+
+#editor-wrapper.show-line-numbers #line-numbers {
+	display: block;
+}
+
+#editor-wrapper.show-line-numbers #editor,
+#editor-wrapper.show-line-numbers #highlight-content {
+	padding-left: 55px;
+}
+
+#line-numbers-inner {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 40px;
+	font-family: "Courier Prime", Courier, monospace;
+	font-size: 15px;
+	line-height: 1.5;
+	padding: 8px 6px 8px 0;
+	box-sizing: border-box;
+	text-align: right;
+	white-space: pre;
+	user-select: none;
+}
+
+.line-number {
+	color: #858585;
+	line-height: inherit;
+}
+
+.line-number.active {
+	color: #c6c6c6;
+}
+
 .hl-keyword {
 	color: #c586c0;
 }

--- a/pages/r2p2/editor/editor_event_handler.rb
+++ b/pages/r2p2/editor/editor_event_handler.rb
@@ -5,6 +5,7 @@ module EditorEventHandler
 
     plain_button = JS.document.getElementById('editor-mode-plain')
     ide_button = JS.document.getElementById('editor-mode-ide')
+    editor_wrapper = JS.document.getElementById('editor-wrapper')
 
     # Prevent the textarea's native Enter from adding a second newline beside auto-indent.
     disable_native_enter_in_ide(editor)
@@ -14,24 +15,34 @@ module EditorEventHandler
 
       editor.dispatchEvent(JS.global[:Event].new('auto-outdent'))
       editor.dispatchEvent(JS.global[:Event].new('refresh-highlight'))
+      editor.dispatchEvent(JS.global[:Event].new('refresh-line-numbers'))
     end
 
     on editor, 'scroll' do
       next unless EditorMode.ide?
 
       editor.dispatchEvent(JS.global[:Event].new('render-highlight-viewport'))
+      editor.dispatchEvent(JS.global[:Event].new('sync-line-number-scroll'))
+    end
+
+    on editor, 'selectionchange' do
+      next unless EditorMode.ide?
+
+      editor.dispatchEvent(JS.global[:Event].new('refresh-active-line-number'))
     end
 
     on plain_button, 'click' do
       plain_button[:classList].add('active')
       ide_button[:classList].remove('active')
-      EditorMode.apply(editor, 'plain')
+      EditorMode.apply(editor, editor_wrapper, 'plain')
     end
 
     on ide_button, 'click' do
       plain_button[:classList].remove('active')
       ide_button[:classList].add('active')
-      EditorMode.apply(editor, 'ide')
+      EditorMode.apply(editor, editor_wrapper, 'ide')
+      editor.dispatchEvent(JS.global[:Event].new('refresh-line-numbers'))
+      editor.dispatchEvent(JS.global[:Event].new('sync-line-number-scroll'))
     end
 
     on editor, "keydown" do |ev|
@@ -39,9 +50,12 @@ module EditorEventHandler
 
       editor.dispatchEvent(JS.global[:Event].new('auto-indent'))
       editor.dispatchEvent(JS.global[:Event].new('refresh-highlight'))
+      editor.dispatchEvent(JS.global[:Event].new('refresh-line-numbers'))
     end
 
-    EditorMode.apply(editor, 'plain')
+    EditorMode.apply(editor, editor_wrapper, 'plain')
+    editor.dispatchEvent(JS.global[:Event].new('refresh-line-numbers'))
+    editor.dispatchEvent(JS.global[:Event].new('sync-line-number-scroll'))
   end
 
   def self.on(target, event_name, &block)

--- a/pages/r2p2/editor/editor_mode.rb
+++ b/pages/r2p2/editor/editor_mode.rb
@@ -6,18 +6,20 @@ module EditorMode
     JS.global[:editorMode].to_s == IDE_MODE_VALUE
   end
 
-  def self.apply(editor, mode)
+  def self.apply(editor, editor_wrapper, mode)
     if mode == IDE_MODE_VALUE
       JS.global[:editorMode] = IDE_MODE_VALUE
       # In IDE mode, make the editor textarea text and background transparent so the syntax highlight layer is visible.
       editor.style[:color] = 'transparent'
       editor.style[:background] = 'transparent'
+      editor_wrapper[:classList].add('show-line-numbers')
 
       editor.dispatchEvent(JS.global[:Event].new('refresh-highlight'))
     else
       JS.global[:editorMode] = PLAIN_MODE_VALUE
       editor.style[:color] = '#f8f8f2'
       editor.style[:background] = '#1a1a1a'
+      editor_wrapper[:classList].remove('show-line-numbers')
     end
   end
 end

--- a/pages/r2p2/editor/line_numbers.rb
+++ b/pages/r2p2/editor/line_numbers.rb
@@ -1,0 +1,120 @@
+require 'js'
+
+module LineNumbers
+  class << self
+    def init
+      editor = JS.document.getElementById('editor')
+      line_numbers = JS.document.getElementById('line-numbers-inner')
+
+      session = Session.new(editor, line_numbers)
+      session.attach
+    end
+  end
+
+  class Session
+    def initialize(editor, line_numbers)
+      @editor = editor
+      @line_numbers = line_numbers
+      # Initialize to -1 so the first render_line_numbers always runs.
+      @rendered_total_line_count = -1
+      @rendered_active_line_number = -1
+    end
+
+    def attach
+      @editor.addEventListener('sync-line-number-scroll') do
+        sync_scroll
+      end
+
+      @editor.addEventListener('refresh-line-numbers') do
+        refresh_line_numbers
+      end
+
+      @editor.addEventListener('refresh-active-line-number') do
+        refresh_active_line_number
+      end
+    end
+
+    private
+
+    def sync_scroll
+      @line_numbers[:style][:top] = "#{-@editor[:scrollTop].to_i}px"
+    end
+
+    def refresh_line_numbers
+      editor_text = @editor[:value].to_s
+      cursor_position = @editor[:selectionStart].to_i
+
+      render_line_numbers(
+        LineMetrics.line_count(editor_text),
+        LineMetrics.active_line_number(editor_text, cursor_position)
+      )
+    end
+
+    def refresh_active_line_number
+      editor_text = @editor[:value].to_s
+      cursor_position = @editor[:selectionStart].to_i
+
+      render_line_numbers(
+        @rendered_total_line_count,
+        LineMetrics.active_line_number(editor_text, cursor_position)
+      )
+    end
+
+    def render_line_numbers(total_line_count, active_line_number)
+      return if total_line_count == @rendered_total_line_count &&
+                active_line_number == @rendered_active_line_number
+
+      @line_numbers[:innerHTML] =
+        HtmlBuilder.make_line_numbers_html(total_line_count, active_line_number)
+
+      @rendered_total_line_count = total_line_count
+      @rendered_active_line_number = active_line_number
+    end
+  end
+
+  module LineMetrics
+    class << self
+      def line_count(text)
+        count = text.split("\n", -1).length
+
+        # An empty buffer is still one line.
+        if count < 1
+          1
+        else
+          count
+        end
+      end
+
+      def active_line_number(editor_text, cursor_position)
+        text_before_cursor = editor_text[0...cursor_position]
+
+        line_count(text_before_cursor)
+      end
+    end
+  end
+
+  module HtmlBuilder
+    class << self
+      def make_line_numbers_html(line_count, active_line_number)
+        (1..line_count).map { |line_number|
+          make_line_number_html(line_number, active_line_number)
+        }.join("\n")
+      end
+
+      private
+
+      def make_line_number_html(line_number, active_line_number)
+        cls =
+          if line_number == active_line_number
+            'line-number active'
+          else
+            'line-number'
+          end
+
+        "<span class=\"#{cls}\">#{line_number}</span>"
+      end
+    end
+  end
+end
+
+LineNumbers.init

--- a/pages/r2p2/terminal.html
+++ b/pages/r2p2/terminal.html
@@ -76,6 +76,9 @@ folder: r2p2
     </div>
     <div id="editor-container" class="editor-container">
       <div id="editor-wrapper">
+        <div id="line-numbers">
+          <div id="line-numbers-inner"></div>
+        </div>
         <div id="highlight-layer">
           <div id="highlight-content"></div>
         </div>
@@ -109,10 +112,11 @@ folder: r2p2
 
   <!-- Web Editor -->
   <script type="text/ruby" src="pages/r2p2/editor/editor_mode.rb"></script>
-  <script type="text/ruby" src="pages/r2p2/editor/editor_event_handler.rb"></script>
   <script type="module" src="pages/r2p2/editor/tokenizer/prismLoader.js"></script>
   <script type="text/ruby" src="pages/r2p2/editor/tokenizer/tokenizer.rb"></script>
   <script type="text/ruby" src="pages/r2p2/editor/highlight.rb"></script>
   <script type="text/ruby" src="pages/r2p2/editor/auto_indent.rb"></script>
+  <script type="text/ruby" src="pages/r2p2/editor/line_numbers.rb"></script>
+  <script type="text/ruby" src="pages/r2p2/editor/editor_event_handler.rb"></script>
 </body>
 </html>

--- a/pages/r2p2/terminal.rb
+++ b/pages/r2p2/terminal.rb
@@ -78,6 +78,10 @@ class App
     el('editor').style.fontSize = font_size
     # Match the textarea font size so the highlight display stays aligned.
     el('highlight-content').style.fontSize = font_size
+    # Match the line-number font size so each line lines up with the editor rows.
+    el('line-numbers-inner').style.fontSize = font_size
+    el('editor').dispatchEvent(JS.global[:Event].new('refresh-highlight'))
+    el('editor').dispatchEvent(JS.global[:Event].new('sync-line-number-scroll'))
   end
 
   def set_term_font(val)


### PR DESCRIPTION
# Add line numbers to the Web Editor

## Overview

Added a line-number gutter to the R2P2 terminal Web Editor (IDE mode). It shows
the line count, highlights the caret's line number, and scrolls in sync with the textarea.

## Changes

- Added `line_numbers.rb` as the main implementation for line number display
