### PR TITLE
Fix auto indent/outdent crash by using Ruby String methods

### DIFF
--- a/pages/r2p2/editor/auto_indent.rb
+++ b/pages/r2p2/editor/auto_indent.rb
@@ -161,11 +161,11 @@ module AutoIndent
       end
 
       def char_at(editor_text, index)
-        editor_text.charAt(index).to_s
+        editor_text[index].to_s
       end
 
       def slice_text(editor_text, start_index, end_index)
-        editor_text.slice(start_index, end_index).to_s
+        editor_text[start_index...end_index]
       end
 
       def newline_char?(character)


### PR DESCRIPTION
  auto_indent was crashing because editor[:value] returned a different type than expected (JS object → Ruby String). This PR
  fixes that.

  Main bugs:

  - NoMethodError from .charAt
  - Various errors caused by .slice running as a Ruby method rather than the JS one